### PR TITLE
Precompile the assets file

### DIFF
--- a/denguetorpedo/deploy.sh
+++ b/denguetorpedo/deploy.sh
@@ -3,4 +3,6 @@ cd /home/dengue/denguetorpedo
 bundle install
 kill -9 `cat /home/dengue/denguetorpedo/tmp/pids/server.pid`
 rm -f /home/dengue/denguetorpedo/tmp/pids/server.pid
+RAILS_ENV=production 
+rake assets:precompile
 bundle exec foreman start


### PR DESCRIPTION
In production the form to write a message in the forum is not displayed and in the Datos/Visitas section there is an error on the map. Everything is because the files are not compiled in the assets of the project.
We propose to add the following line to the deploy.sh file of the docker-compose:

RAILS_ENV = production rake assets: precompile

When the deploy.sh is executed, the assets folder is created with the compiled files inside the public folder of the project.

[Issue where the error is reported](https://github.com/socialappslab/denguetorpedo/issues/959)